### PR TITLE
Fix the updater crashing when trying to update certs

### DIFF
--- a/classes/CliLogger.php
+++ b/classes/CliLogger.php
@@ -9,7 +9,12 @@ class CliLogger {
 
     protected $cli;
 
-    public function __construct(\DokuCLI $cli) {
+    /**
+     * CliLogger constructor.
+     *
+     * @param \DokuCLI|\splitbrain\phpcli\CLI $cli
+     */
+    public function __construct($cli) {
         $this->cli = $cli;
     }
 

--- a/helper.php
+++ b/helper.php
@@ -36,7 +36,7 @@ class helper_plugin_letsencrypt extends DokuWiki_Plugin {
 
     /**
      * switch to Console logging
-     * @param DokuCLI $cli
+     * @param \DokuCLI|\splitbrain\phpcli\CLI $cli
      */
     public function setCliLogger($cli) {
         $this->logger = new CliLogger($cli);


### PR DESCRIPTION
This fixes the crash introduced in pull request #5.
This crash would only occur when the cli actually tries to update the certificates and it was caused by an overlooked typehint.
This explicit typehint has been replaced by a typehint in the php docblock.